### PR TITLE
Add check runner: HTTP checker and cron API route

### DIFF
--- a/src/__tests__/check-runner.test.ts
+++ b/src/__tests__/check-runner.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Mock the checker module
+vi.mock('@/lib/checker', () => ({
+  checkSite: vi.fn(),
+}))
+
+// Mock the admin client
+const mockFrom = vi.fn()
+const mockSupabase = { from: mockFrom }
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => mockSupabase,
+}))
+
+import { POST } from '@/app/api/checks/run/route'
+import { checkSite } from '@/lib/checker'
+
+describe('POST /api/checks/run', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'test-secret'
+  })
+
+  test('rejects requests without valid CRON_SECRET', async () => {
+    const request = new NextRequest('http://localhost/api/checks/run', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-secret' },
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+  })
+
+  test('rejects requests with no authorization header', async () => {
+    const request = new NextRequest('http://localhost/api/checks/run', {
+      method: 'POST',
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+  })
+
+  test('returns empty result when no sites exist', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        data: [],
+        error: null,
+      }),
+    })
+
+    const request = new NextRequest('http://localhost/api/checks/run', {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-secret' },
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+    expect(body).toEqual({ message: 'No sites to check', checks: 0, incidents: 0 })
+  })
+
+  test('records checks and opens incidents for failures', async () => {
+    const site = { id: 'site-1', name: 'Test', url: 'https://example.com' }
+
+    // Mock sites query
+    const mockSelect = vi.fn()
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'sites') {
+        return { select: () => ({ data: [site], error: null }) }
+      }
+      if (table === 'checks') {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: () => ({
+                data: { id: 'check-1', site_id: 'site-1', status: 'failure' },
+              }),
+            }),
+          }),
+        }
+      }
+      if (table === 'incidents') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: () => ({
+                  single: () => ({ data: null }),
+                }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockReturnValue({ data: null, error: null }),
+        }
+      }
+      return { select: mockSelect }
+    })
+
+    vi.mocked(checkSite).mockResolvedValue({
+      status: 'failure',
+      statusCode: 503,
+      error: 'HTTP 503',
+    })
+
+    const request = new NextRequest('http://localhost/api/checks/run', {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-secret' },
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+    expect(body.checks).toBe(1)
+    expect(body.incidents).toBe(1)
+  })
+})

--- a/src/__tests__/checker.test.ts
+++ b/src/__tests__/checker.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { checkSite } from '@/lib/checker'
+
+describe('checkSite', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('returns success for HTTP 200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    }))
+
+    const result = await checkSite('https://example.com')
+    expect(result).toEqual({ status: 'success', statusCode: 200, error: null })
+  })
+
+  test('returns failure for HTTP 503', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+    }))
+
+    const result = await checkSite('https://example.com')
+    expect(result).toEqual({ status: 'failure', statusCode: 503, error: 'HTTP 503' })
+  })
+
+  test('returns failure on timeout', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      const error = new Error('The operation was aborted')
+      error.name = 'AbortError'
+      return Promise.reject(error)
+    }))
+
+    const result = await checkSite('https://example.com')
+    expect(result).toEqual({ status: 'failure', statusCode: null, error: 'Connection timeout' })
+  })
+
+  test('returns failure on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(
+      new Error('getaddrinfo ENOTFOUND example.com')
+    ))
+
+    const result = await checkSite('https://example.com')
+    expect(result).toEqual({
+      status: 'failure',
+      statusCode: null,
+      error: 'getaddrinfo ENOTFOUND example.com',
+    })
+  })
+
+  test('returns failure on SSL error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(
+      new Error('unable to verify the first certificate')
+    ))
+
+    const result = await checkSite('https://example.com')
+    expect(result).toEqual({
+      status: 'failure',
+      statusCode: null,
+      error: 'unable to verify the first certificate',
+    })
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/checks/run",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/checker.ts` — HTTP checking function with 30s timeout, redirect following, and error categorization
- Adds `src/app/api/checks/run/route.ts` — POST endpoint gated by `CRON_SECRET`, fetches all sites, checks each concurrently, records check results, and opens incidents for new failures
- Adds `vercel.json` with `*/5 * * * *` cron schedule
- Adds comprehensive unit tests for both the checker module (5 tests) and the route handler (4 tests)
- Updates `vitest.config.ts` with `@` path alias

## Test plan
- [x] All 15 Vitest tests pass (including 9 new tests)
- [x] Next.js build succeeds with no type errors
- [ ] CI passes on this PR

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)