### PR TITLE
Add sites CRUD with admin UI on status page

### DIFF
--- a/src/__tests__/sites-crud.test.ts
+++ b/src/__tests__/sites-crud.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+
+// Mock next/cache
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// Mock next/navigation
+const mockRedirect = vi.fn()
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    mockRedirect(url)
+    throw new Error(`NEXT_REDIRECT:${url}`)
+  },
+}))
+
+// Mock Supabase server client
+const mockFrom = vi.fn()
+const mockGetUser = vi.fn()
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+    }),
+}))
+
+import { addSite, editSite, deleteSite } from "@/app/sites/actions"
+
+describe("addSite action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("redirects unauthenticated users to login", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const formData = new FormData()
+    formData.set("name", "Test Site")
+    formData.set("url", "https://example.com")
+
+    await expect(addSite(formData)).rejects.toThrow("NEXT_REDIRECT:/login")
+  })
+
+  test("inserts site for authenticated users", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    })
+
+    const mockInsert = vi.fn().mockReturnValue({ error: null })
+    mockFrom.mockReturnValue({ insert: mockInsert })
+
+    const formData = new FormData()
+    formData.set("name", "Test Site")
+    formData.set("url", "https://example.com")
+
+    await addSite(formData)
+    expect(mockFrom).toHaveBeenCalledWith("sites")
+    expect(mockInsert).toHaveBeenCalledWith({
+      name: "Test Site",
+      url: "https://example.com",
+    })
+  })
+
+  test("does nothing if name or url is empty", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    })
+
+    const formData = new FormData()
+    formData.set("name", "Test Site")
+    // url is missing
+
+    await addSite(formData)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+})
+
+describe("editSite action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("redirects unauthenticated users to login", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const formData = new FormData()
+    formData.set("name", "Updated")
+    formData.set("url", "https://example.com")
+
+    await expect(editSite("site-1", formData)).rejects.toThrow(
+      "NEXT_REDIRECT:/login"
+    )
+  })
+
+  test("updates site for authenticated users", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    })
+
+    const mockEq = vi.fn().mockReturnValue({ error: null })
+    const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ update: mockUpdate })
+
+    const formData = new FormData()
+    formData.set("name", "Updated Site")
+    formData.set("url", "https://updated.com")
+
+    await editSite("site-1", formData)
+    expect(mockFrom).toHaveBeenCalledWith("sites")
+    expect(mockUpdate).toHaveBeenCalledWith({
+      name: "Updated Site",
+      url: "https://updated.com",
+    })
+    expect(mockEq).toHaveBeenCalledWith("id", "site-1")
+  })
+
+  test("does nothing if name or url is empty", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    })
+
+    const formData = new FormData()
+    // both fields empty
+
+    await editSite("site-1", formData)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+})
+
+describe("deleteSite action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("redirects unauthenticated users to login", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    await expect(deleteSite("site-1")).rejects.toThrow("NEXT_REDIRECT:/login")
+  })
+
+  test("deletes site for authenticated users", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    })
+
+    const mockEq = vi.fn().mockReturnValue({ error: null })
+    const mockDelete = vi.fn().mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ delete: mockDelete })
+
+    await deleteSite("site-1")
+    expect(mockFrom).toHaveBeenCalledWith("sites")
+    expect(mockEq).toHaveBeenCalledWith("id", "site-1")
+  })
+})

--- a/src/app/sites/actions.ts
+++ b/src/app/sites/actions.ts
@@ -1,0 +1,52 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+export async function addSite(formData: FormData) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect("/login")
+
+  const name = (formData.get("name") as string)?.trim()
+  const url = (formData.get("url") as string)?.trim()
+
+  if (!name || !url) return
+
+  await supabase.from("sites").insert({ name, url })
+  revalidatePath("/")
+}
+
+export async function editSite(siteId: string, formData: FormData) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect("/login")
+
+  const name = (formData.get("name") as string)?.trim()
+  const url = (formData.get("url") as string)?.trim()
+
+  if (!name || !url) return
+
+  await supabase.from("sites").update({ name, url }).eq("id", siteId)
+  revalidatePath("/")
+  revalidatePath(`/sites/${siteId}`)
+}
+
+export async function deleteSite(siteId: string) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect("/login")
+
+  await supabase.from("sites").delete().eq("id", siteId)
+  revalidatePath("/")
+}

--- a/src/components/AddSiteCard.tsx
+++ b/src/components/AddSiteCard.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useState } from "react"
+import { addSite } from "@/app/sites/actions"
+
+export default function AddSiteCard() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center justify-center flex-col gap-1.5 rounded cursor-pointer"
+        style={{
+          background: "transparent",
+          border: "1.5px dashed #D4CFC9",
+          padding: "24px 18px",
+          color: "#8A8A8A",
+          minHeight: "108px",
+          transition: "border-color 0.15s, color 0.15s",
+        }}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        >
+          <path d="M8 3v10M3 8h10" />
+        </svg>
+        <span className="text-[13px] font-medium">Add site</span>
+      </button>
+    )
+  }
+
+  return (
+    <div
+      className="rounded"
+      style={{
+        backgroundColor: "#FFFFFF",
+        border: "1px solid #E8E4DF",
+        padding: "16px 18px",
+      }}
+    >
+      <form
+        action={async (formData) => {
+          await addSite(formData)
+          setIsOpen(false)
+        }}
+        className="flex flex-col gap-2"
+      >
+        <input
+          type="text"
+          name="name"
+          placeholder="Site name"
+          required
+          autoFocus
+          className="text-sm px-3 py-2 rounded outline-none"
+          style={{
+            border: "1px solid #E8E4DF",
+            backgroundColor: "#FFFFFF",
+            color: "#1A1A1A",
+          }}
+        />
+        <input
+          type="url"
+          name="url"
+          placeholder="https://example.com"
+          required
+          className="text-sm px-3 py-2 rounded outline-none"
+          style={{
+            border: "1px solid #E8E4DF",
+            backgroundColor: "#FFFFFF",
+            color: "#1A1A1A",
+          }}
+        />
+        <div className="flex gap-2 mt-1">
+          <button
+            type="submit"
+            className="text-sm font-medium px-3 py-1.5 rounded cursor-pointer text-white"
+            style={{ backgroundColor: "#2C2C2C" }}
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="text-sm px-3 py-1.5 rounded cursor-pointer"
+            style={{
+              backgroundColor: "transparent",
+              color: "#5C5C5C",
+              border: "1px solid #E8E4DF",
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/EditSiteButton.tsx
+++ b/src/components/EditSiteButton.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useState } from "react"
+import { editSite, deleteSite } from "@/app/sites/actions"
+
+export default function EditSiteButton({
+  siteId,
+  name,
+  url,
+}: {
+  siteId: string
+  name: string
+  url: string
+}) {
+  const [isEditing, setIsEditing] = useState(false)
+
+  if (!isEditing) {
+    return (
+      <button
+        onClick={() => setIsEditing(true)}
+        className="flex items-center justify-center rounded cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+        style={{
+          width: "28px",
+          height: "28px",
+          color: "#5C5C5C",
+          background: "transparent",
+          border: "none",
+        }}
+        title="Edit site"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M11.5 1.5l3 3-9 9H2.5v-3z" />
+          <path d="M10 3l3 3" />
+        </svg>
+      </button>
+    )
+  }
+
+  return (
+    <div
+      className="absolute inset-0 rounded z-10"
+      style={{
+        backgroundColor: "#FFFFFF",
+        border: "1px solid #E8E4DF",
+        padding: "16px 18px",
+      }}
+    >
+      <form
+        action={editSite.bind(null, siteId)}
+        className="flex flex-col gap-2"
+      >
+        <input
+          type="text"
+          name="name"
+          defaultValue={name}
+          required
+          autoFocus
+          className="text-sm px-3 py-2 rounded outline-none"
+          style={{
+            border: "1px solid #E8E4DF",
+            backgroundColor: "#FFFFFF",
+            color: "#1A1A1A",
+          }}
+        />
+        <input
+          type="url"
+          name="url"
+          defaultValue={url}
+          required
+          className="text-sm px-3 py-2 rounded outline-none"
+          style={{
+            border: "1px solid #E8E4DF",
+            backgroundColor: "#FFFFFF",
+            color: "#1A1A1A",
+          }}
+        />
+        <div className="flex gap-2 mt-1">
+          <button
+            type="submit"
+            className="text-sm font-medium px-3 py-1.5 rounded cursor-pointer text-white"
+            style={{ backgroundColor: "#2C2C2C" }}
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsEditing(false)}
+            className="text-sm px-3 py-1.5 rounded cursor-pointer"
+            style={{
+              backgroundColor: "transparent",
+              color: "#5C5C5C",
+              border: "1px solid #E8E4DF",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => deleteSite(siteId)}
+            className="text-sm px-3 py-1.5 rounded cursor-pointer ml-auto"
+            style={{
+              backgroundColor: "transparent",
+              color: "#C4453C",
+              border: "1px solid #E8E4DF",
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Server actions for add, edit, and delete sites (`src/app/sites/actions.ts`) with auth checks
- "Add site" dashed card in the sites grid (admin-only, inline form)
- Edit pencil icon on each site card with inline edit/delete overlay (admin-only)
- Status page now checks auth and conditionally shows admin controls
- 8 new tests covering all CRUD operations and auth enforcement

Closes #6

## Test plan
- [ ] Verify `addSite` inserts a site and revalidates `/`
- [ ] Verify `editSite` updates name/url and revalidates
- [ ] Verify `deleteSite` removes a site
- [ ] Verify unauthenticated users see no admin controls
- [ ] Verify unauthenticated CRUD requests redirect to login
- [ ] All 51 tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)