### PR TITLE
Fix site edit button visibility and overlay

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -184,13 +184,12 @@ export default async function StatusPage() {
                   </div>
                 </Link>
                 {isAdmin && (
-                  <div className="absolute top-3 right-3">
-                    <EditSiteButton
-                      siteId={site.id}
-                      name={site.name}
-                      url={site.url}
-                    />
-                  </div>
+                  <EditSiteButton
+                    siteId={site.id}
+                    name={site.name}
+                    url={site.url}
+                    overlay
+                  />
                 )}
               </div>
             ))}

--- a/src/components/EditSiteButton.tsx
+++ b/src/components/EditSiteButton.tsx
@@ -7,10 +7,12 @@ export default function EditSiteButton({
   siteId,
   name,
   url,
+  overlay,
 }: {
   siteId: string
   name: string
   url: string
+  overlay?: boolean
 }) {
   const [isEditing, setIsEditing] = useState(false)
 
@@ -18,7 +20,11 @@ export default function EditSiteButton({
     return (
       <button
         onClick={() => setIsEditing(true)}
-        className="flex items-center justify-center rounded cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+        className={`flex items-center justify-center rounded cursor-pointer flex-shrink-0${
+          overlay
+            ? " absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity"
+            : ""
+        }`}
         style={{
           width: "28px",
           height: "28px",
@@ -47,7 +53,7 @@ export default function EditSiteButton({
 
   return (
     <div
-      className="absolute inset-0 rounded z-10"
+      className={overlay ? "absolute inset-0 rounded z-10" : "rounded"}
       style={{
         backgroundColor: "#FFFFFF",
         border: "1px solid #E8E4DF",


### PR DESCRIPTION
## Summary
- **#28 (edit button missing on detail page)**: The pencil button had `opacity-0 group-hover:opacity-100` but the site detail page had no `group` ancestor, so it was permanently invisible
- **#29 (broken edit overlay on main page)**: The edit form used `absolute inset-0` but was nested inside a `<div className="absolute top-3 right-3">` wrapper, which became its containing block instead of the card — producing mispositioned overlapping rectangles

Both fixed by adding an `overlay` prop to `EditSiteButton`. When `overlay` is true (main page cards), the component self-positions absolutely and the form fills the card. When false (detail page), both button and form render inline and are always visible.

## Test plan
- [x] Build passes
- [x] All 88 unit tests pass
- [ ] CI passes

Fixes #28, fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)