### PR TITLE
Add seed.sql for Supabase branch databases

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,71 @@
+-- Seed data for Supabase branch databases (preview deploys)
+-- This file runs automatically when a branch DB is created via Supabase Branching.
+
+-- ============================================================================
+-- Test auth user: test@example.com / testpassword123
+-- ============================================================================
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  recovery_token
+) VALUES (
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'test@example.com',
+  crypt('testpassword123', gen_salt('bf')),
+  now(),
+  '{"provider": "email", "providers": ["email"]}',
+  '{}',
+  now(),
+  now(),
+  '',
+  ''
+);
+
+INSERT INTO auth.identities (
+  id,
+  user_id,
+  identity_data,
+  provider,
+  provider_id,
+  last_sign_in_at,
+  created_at,
+  updated_at
+) VALUES (
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  jsonb_build_object('sub', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'email', 'test@example.com'),
+  'email',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  now(),
+  now(),
+  now()
+);
+
+-- ============================================================================
+-- Sample sites
+-- ============================================================================
+
+INSERT INTO sites (id, name, url) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'Example Site', 'https://example.com'),
+  ('22222222-2222-2222-2222-222222222222', 'Anthropic', 'https://www.anthropic.com');
+
+-- ============================================================================
+-- Test contact
+-- ============================================================================
+
+INSERT INTO contacts (email) VALUES
+  ('test@example.com');


### PR DESCRIPTION
## Summary
- Adds `supabase/seed.sql` with test data for Supabase Branching (preview deploy databases)
- Creates a test auth user (`test@example.com` / `testpassword123`), two sample sites, and a test contact
- The `config.toml` already references `./seed.sql` with seeding enabled — no config changes needed

## Manual dashboard steps (not automatable)
After merging, complete the Supabase Branching setup:
1. **Supabase Pro plan** — upgrade if not already
2. **Install Supabase Vercel integration** — connect site-status projects
3. **Enable GitHub integration in Supabase** — authorize repo, set directory to `./supabase`
4. **Enable Branching** — confirm production branch is `main`
5. **Vercel env vars** — leave `RESEND_API_KEY` / `RESEND_FROM_EMAIL` unset for Preview scope

## Test plan
- [ ] Open a test PR after Supabase Branching is enabled
- [ ] Verify branch DB is created in Supabase Dashboard
- [ ] Verify preview deploy uses branch-specific Supabase URL
- [ ] Log in with `test@example.com` / `testpassword123` on preview
- [ ] Add a site on preview, confirm prod is unaffected
- [ ] Close test PR, verify branch DB is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)