### PR TITLE
feat: display dates in user's local timezone

### DIFF
--- a/src/app/incidents/[id]/page.tsx
+++ b/src/app/incidents/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import type { Incident, Site, Check } from "@/lib/supabase/types"
 import CheckLogTable from "@/components/CheckLogTable"
+import { LocalDateTime } from "@/components/LocalTime"
 import { resolveIncident } from "./actions"
 
 export const revalidate = 0
@@ -113,28 +114,12 @@ export default async function IncidentDetailPage({
         <div className="mt-3 flex flex-col gap-1.5">
           <div className="text-sm flex items-center gap-1.5" style={{ color: "#5C5C5C" }}>
             <span>
-              Opened{" "}
-              {new Date(incident.opened_at).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-              })},{" "}
-              {new Date(incident.opened_at).toLocaleTimeString("en-US", {
-                hour: "numeric",
-                minute: "2-digit",
-              })}
+              Opened <LocalDateTime dateString={incident.opened_at} />
             </span>
           </div>
           {incident.resolved_at && (
             <div className="text-sm" style={{ color: "#5C5C5C" }}>
-              Resolved{" "}
-              {new Date(incident.resolved_at).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-              })},{" "}
-              {new Date(incident.resolved_at).toLocaleTimeString("en-US", {
-                hour: "numeric",
-                minute: "2-digit",
-              })}
+              Resolved <LocalDateTime dateString={incident.resolved_at} />
             </div>
           )}
           <div className="text-sm flex items-center gap-1.5" style={{ color: "#5C5C5C" }}>

--- a/src/app/incidents/page.tsx
+++ b/src/app/incidents/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
-import { formatIncidentRange } from "@/lib/format"
+import { LocalIncidentRange } from "@/components/LocalTime"
 
 export const revalidate = 0
 
@@ -101,10 +101,10 @@ export default async function AllIncidentsPage() {
                     </div>
                   )}
                   <div className="text-[13px]" style={{ color: "#807B74" }}>
-                    {formatIncidentRange(
-                      incident.opened_at,
-                      incident.resolved_at
-                    )}
+                    <LocalIncidentRange
+                      openedAt={incident.opened_at}
+                      resolvedAt={incident.resolved_at}
+                    />
                   </div>
                 </div>
               </Link>

--- a/src/app/sites/[id]/incidents/page.tsx
+++ b/src/app/sites/[id]/incidents/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
-import { formatIncidentRange } from "@/lib/format"
+import { LocalIncidentRange } from "@/components/LocalTime"
 
 export const revalidate = 0
 
@@ -111,10 +111,10 @@ export default async function SiteIncidentsPage({
                     </span>
                   </div>
                   <div className="text-[13px]" style={{ color: "#5C5C5C" }}>
-                    {formatIncidentRange(
-                      incident.opened_at,
-                      incident.resolved_at
-                    )}
+                    <LocalIncidentRange
+                      openedAt={incident.opened_at}
+                      resolvedAt={incident.resolved_at}
+                    />
                   </div>
                 </div>
               </Link>

--- a/src/app/sites/[id]/page.tsx
+++ b/src/app/sites/[id]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
-import { formatIncidentRange } from "@/lib/format"
+import { LocalIncidentRange } from "@/components/LocalTime"
 import SiteFormDialog from "@/components/SiteFormDialog"
 import CheckLogTable from "@/components/CheckLogTable"
 
@@ -155,7 +155,10 @@ export default async function SiteDetailPage({
                       </span>
                     </div>
                     <div className="text-[13px]" style={{ color: "#5C5C5C" }}>
-                      {formatIncidentRange(incident.opened_at, incident.resolved_at)}
+                      <LocalIncidentRange
+                        openedAt={incident.opened_at}
+                        resolvedAt={incident.resolved_at}
+                      />
                     </div>
                   </div>
                 </Link>

--- a/src/components/CheckLogTable.tsx
+++ b/src/components/CheckLogTable.tsx
@@ -1,5 +1,8 @@
+"use client"
+
 import type { Check } from "@/lib/supabase/types"
 import { isSoftFailure } from "@/lib/checker"
+import { LocalDateTime } from "@/components/LocalTime"
 
 function checkDotColor(check: Check): string {
   if (check.status !== "failure") return "#2DA44E"
@@ -70,14 +73,7 @@ export default function CheckLogTable({
                     className="px-5 py-2.5 text-sm whitespace-nowrap"
                     style={{ color: "#5C5C5C", fontVariantNumeric: "tabular-nums" }}
                   >
-                    {new Date(check.checked_at).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                    })}{" "}
-                    {new Date(check.checked_at).toLocaleTimeString("en-US", {
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
+                    <LocalDateTime dateString={check.checked_at} />
                   </td>
                   <td className="px-5 py-2.5">
                     <div className="flex items-center gap-2">

--- a/src/components/LocalTime.tsx
+++ b/src/components/LocalTime.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { getTimeZone, formatIncidentRange, formatDateTime } from "@/lib/format"
+
+export function LocalIncidentRange({
+  openedAt,
+  resolvedAt,
+}: {
+  openedAt: string
+  resolvedAt: string | null
+}) {
+  const tz = getTimeZone()
+  return (
+    <span suppressHydrationWarning>
+      {formatIncidentRange(openedAt, resolvedAt, tz)}
+    </span>
+  )
+}
+
+export function LocalDateTime({ dateString }: { dateString: string }) {
+  const tz = getTimeZone()
+  return (
+    <span suppressHydrationWarning>
+      {formatDateTime(dateString, tz)}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- Detect the browser's timezone via `Intl` API (fallback: US Pacific) and display all dates/times in the user's local time with a short abbreviation (e.g., PST, EDT)
- New `LocalIncidentRange` and `LocalDateTime` client components handle timezone-aware rendering with `suppressHydrationWarning`
- Updated all 5 call sites (incident lists, incident detail, check log table) to use the new components
- Added 11 tests covering `formatIncidentRange` and `formatDateTime` across Eastern, Pacific, and UTC timezones

Closes #50

## Test plan
- [x] `npx vitest run` — all 112 tests pass (26 format tests including 11 new)
- [x] `npx next lint` — clean (no new warnings)
- [ ] Verify on preview deploy: dates show timezone abbreviation and reflect local time
- [ ] Check DST abbreviation correctness (PST vs PDT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)