### PR TITLE
feat: enable real-time updates on all pages

### DIFF
--- a/src/app/incidents/[id]/page.tsx
+++ b/src/app/incidents/[id]/page.tsx
@@ -6,6 +6,7 @@ import CheckLogTable from "@/components/CheckLogTable"
 import { LocalDateTime } from "@/components/LocalTime"
 import { resolveIncident } from "./actions"
 import ActionForm from "@/components/ActionForm"
+import RealtimeIncidentDetail from "@/components/RealtimeIncidentDetail"
 
 export const revalidate = 0
 
@@ -62,6 +63,7 @@ export default async function IncidentDetailPage({
 
   return (
     <main className="max-w-[720px] mx-auto" style={{ padding: "32px 24px 64px" }}>
+      <RealtimeIncidentDetail siteId={incident.site_id} incidentId={id} />
       <div className="mb-7">
         <Link
           href={`/sites/${incident.site_id}`}

--- a/src/app/incidents/page.tsx
+++ b/src/app/incidents/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
 import { LocalIncidentRange } from "@/components/LocalTime"
+import RealtimeAllIncidents from "@/components/RealtimeAllIncidents"
 
 export const revalidate = 0
 
@@ -27,6 +28,7 @@ export default async function AllIncidentsPage() {
       className="max-w-[960px] mx-auto"
       style={{ padding: "36px 24px 80px" }}
     >
+      <RealtimeAllIncidents />
       <div className="mb-7">
         <Link
           href="/"

--- a/src/app/sites/[id]/incidents/page.tsx
+++ b/src/app/sites/[id]/incidents/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
 import { LocalIncidentRange } from "@/components/LocalTime"
+import RealtimeSiteDetail from "@/components/RealtimeSiteDetail"
 
 export const revalidate = 0
 
@@ -45,6 +46,7 @@ export default async function SiteIncidentsPage({
       className="max-w-[820px] mx-auto"
       style={{ padding: "32px 24px 80px" }}
     >
+      <RealtimeSiteDetail siteId={id} />
       <div className="mb-7">
         <Link
           href={`/sites/${site.id}`}

--- a/src/app/sites/[id]/page.tsx
+++ b/src/app/sites/[id]/page.tsx
@@ -5,6 +5,7 @@ import type { Site, Check, Incident } from "@/lib/supabase/types"
 import { LocalIncidentRange } from "@/components/LocalTime"
 import SiteFormDialog from "@/components/SiteFormDialog"
 import CheckLogTable from "@/components/CheckLogTable"
+import RealtimeSiteDetail from "@/components/RealtimeSiteDetail"
 
 export const revalidate = 0
 
@@ -56,6 +57,7 @@ export default async function SiteDetailPage({
 
   return (
     <main className="max-w-[820px] mx-auto" style={{ padding: "32px 24px 80px" }}>
+      <RealtimeSiteDetail siteId={id} />
       <div className="mb-7">
         <Link
           href="/"

--- a/src/components/RealtimeAllIncidents.tsx
+++ b/src/components/RealtimeAllIncidents.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { useMemo } from "react"
+import { useRealtimeSubscription } from "@/hooks/useRealtimeSubscription"
+
+export default function RealtimeAllIncidents() {
+  const subscriptions = useMemo(
+    () => [
+      { table: "incidents" },
+    ],
+    []
+  )
+  useRealtimeSubscription(subscriptions)
+  return null
+}

--- a/src/components/SiteList.tsx
+++ b/src/components/SiteList.tsx
@@ -210,7 +210,7 @@ export default function SiteList({
   const { showError } = useErrorDialog()
 
   // Sync local state when server data changes (after add/edit/delete revalidation)
-  const serverKey = initialSites.map((s) => `${s.id}:${s.name}:${s.url}`).join("|")
+  const serverKey = initialSites.map((s) => `${s.id}:${s.name}:${s.url}:${s.lastCheck?.checked_at ?? ""}:${s.lastCheck?.status ?? ""}`).join("|")
   const prevServerKey = useRef(serverKey)
   if (serverKey !== prevServerKey.current) {
     prevServerKey.current = serverKey


### PR DESCRIPTION
## Summary
- Wire `RealtimeSiteDetail` into site detail page and site incidents page
- Wire `RealtimeIncidentDetail` into incident detail page
- Create `RealtimeAllIncidents` component and add it to the all-incidents page
- Fix `SiteList` serverKey to include `lastCheck.checked_at` and `lastCheck.status` so the homepage "Checked X min ago" text updates after realtime refresh

Closes #63

## Test plan
- [ ] Open homepage in two tabs; trigger a check and verify "Checked X min ago" updates in both without manual refresh
- [ ] Open site detail page (`/sites/[id]`) in two tabs; make a change and verify both update
- [ ] Open site incidents page (`/sites/[id]/incidents`) and verify it updates when an incident opens/resolves
- [ ] Open incident detail page (`/incidents/[id]`) and verify it updates in real time
- [ ] Open all-incidents page (`/incidents`) and verify it updates when incidents change

🤖 Generated with [Claude Code](https://claude.com/claude-code)