### PR TITLE
Fix: refresh relative timestamps every 15 seconds

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link"
 import { createClient } from "@/lib/supabase/server"
 import type { Site, Check, Incident } from "@/lib/supabase/types"
-import { formatDuration } from "@/lib/format"
 import SiteList from "@/components/SiteList"
 import RealtimeStatusPage from "@/components/RealtimeStatusPage"
+import LiveDuration from "@/components/LiveDuration"
 
 export const revalidate = 0
 
@@ -101,7 +101,7 @@ export default async function StatusPage() {
                     className="text-[13px] font-semibold"
                     style={{ color: "#C4453C" }}
                   >
-                    Down for {formatDuration(incident.opened_at)}
+                    <LiveDuration since={incident.opened_at} />
                   </span>
                 </div>
                 <div className="mt-1.5 flex items-center gap-3 flex-wrap">

--- a/src/components/LiveDuration.tsx
+++ b/src/components/LiveDuration.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import { formatDuration } from "@/lib/format"
+import { useTick } from "@/hooks/useTick"
+
+export default function LiveDuration({ since }: { since: string }) {
+  useTick(15_000)
+  return <>Down for {formatDuration(since)}</>
+}

--- a/src/components/SiteList.tsx
+++ b/src/components/SiteList.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useRef, useState } from "react"
+import { useTick } from "@/hooks/useTick"
 import Link from "next/link"
 import {
   DndContext,
@@ -208,6 +209,7 @@ export default function SiteList({
 }) {
   const [sites, setSites] = useState(initialSites)
   const { showError } = useErrorDialog()
+  useTick(15_000)
 
   // Sync local state when server data changes (after add/edit/delete revalidation)
   const serverKey = initialSites.map((s) => `${s.id}:${s.name}:${s.url}:${s.lastCheck?.checked_at ?? ""}:${s.lastCheck?.status ?? ""}`).join("|")

--- a/src/hooks/useTick.ts
+++ b/src/hooks/useTick.ts
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect, useReducer } from "react"
+
+/**
+ * Forces a re-render at the given interval (in ms).
+ * Useful for keeping relative timestamps fresh.
+ */
+export function useTick(intervalMs: number = 15_000) {
+  const [, tick] = useReducer((x: number) => x + 1, 0)
+
+  useEffect(() => {
+    const id = setInterval(tick, intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+}


### PR DESCRIPTION
## Summary
- Relative timestamps ("Checked 5 min ago", "Down for 23 minutes") were computed once at render time and never updated, causing stale displays on the main status page
- Added a `useTick` hook that forces a lightweight re-render every 15 seconds so `formatTimeAgo` / `formatDuration` recompute against `new Date()`
- Extracted "Down for X" on open incidents into a `LiveDuration` client component so it also stays fresh

## Test plan
- [ ] Open the main status page and wait — "Checked X ago" timestamps should update every 15 seconds
- [ ] If there's an open incident, verify "Down for X" also updates periodically
- [ ] Confirm no visible flicker or performance impact from the 15s tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)