### PR TITLE
Fix: add @channel to Slack alerts for push notifications

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -69,7 +69,7 @@ export async function sendIncidentSlack({
   const incidentLink = `${appUrl}/incidents/${incidentId}`
 
   const text = [
-    `Site status alert: new incident — *${siteName}* is down`,
+    `<!channel> Site status alert: new incident — *${siteName}* is down`,
     `URL: ${siteUrl}`,
     error ? `Error: ${error}` : null,
     `<${incidentLink}|View incident>`,


### PR DESCRIPTION
## Summary
- Slack keyword notifications don't trigger push notifications for webhook/bot messages (keywords get highlighted but no mobile/desktop notification fires)
- Added `<!channel>` to Slack incident alerts so channel members get proper push notifications when a site goes down
- Channel members who don't want alerts can mute the channel or disable @channel notifications in their per-channel settings

## Test plan
- [ ] Trigger a test incident and verify the Slack message includes @channel
- [ ] Confirm push notification is received on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)