### PR TITLE
Add site favicon with pulse/heartbeat design

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#6B806B"/>
+  <polyline
+    points="3,16 9,16 12,8 16,24 20,8 24,16 29,16"
+    fill="none"
+    stroke="#FFFFFF"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG favicon (`src/app/icon.svg`) with a heartbeat/pulse waveform on a green rounded square
- Uses the app's brand green (#6B806B) matching the header
- Next.js automatically serves `icon.svg` from `src/app/` as the favicon — no layout changes needed

Closes #58

## Test plan
- [ ] Verify the favicon appears in the browser tab on the Vercel preview deploy
- [ ] Check it renders clearly at small sizes (16x16, 32x32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)